### PR TITLE
WEBDEV-7387 Don't convert date strs with explicit time zones to local time

### DIFF
--- a/src/field-types/date.ts
+++ b/src/field-types/date.ts
@@ -42,14 +42,14 @@ export class DateParser implements FieldParserInterface<Date> {
       return undefined;
     }
     let date = new Date(parsedValue);
-    // The `Date(string)` constructor parses some strings as GMT and some in the local timezone.
-    // This attempts to detect cases that get parsed as GMT but should be parsed as local.
+    // The `Date(string)` constructor parses some strings as UTC and some in the local timezone.
+    // This attempts to detect cases that get parsed as UTC but should be parsed as local.
     // Note that this does _not_ include cases with an explicit time zone specified, which
     // should generally be parsed as-is and not converted to local time.
-    const dateWithTimeZone =
+    const isUTCTimeZoneInferred =
       parsedValue.match(/^[0-9]{4}$/) || // just the year, ie `2020`
       parsedValue.match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/); // YYYY-MM-DD format
-    if (dateWithTimeZone) {
+    if (isUTCTimeZoneInferred) {
       date = new Date(date.getTime() + date.getTimezoneOffset() * 1000 * 60);
     }
     return date;

--- a/src/field-types/date.ts
+++ b/src/field-types/date.ts
@@ -45,8 +45,6 @@ export class DateParser implements FieldParserInterface<Date> {
     // the `Date(string)` constructor parses some strings as GMT and some in the local timezone
     // this attempts to detect cases that get parsed as GMT and adjusts accordingly
     const dateWithTimeZone =
-      parsedValue.indexOf('Z') > -1 || // ISO8601 with GMT timezone
-      parsedValue.indexOf('+') > -1 || // ISO8601 with positive timezone offset
       parsedValue.match(/^[0-9]{4}$/) || // just the year, ie `2020`
       parsedValue.match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/) || // YYYY-MM-DD format
       parsedValue.match(/^.*?-[0-9]{2}:[0-9]{2}$/) || // `YYYY-MM-DDTHH:mm:ss-00:00` format

--- a/src/field-types/date.ts
+++ b/src/field-types/date.ts
@@ -46,9 +46,7 @@ export class DateParser implements FieldParserInterface<Date> {
     // this attempts to detect cases that get parsed as GMT and adjusts accordingly
     const dateWithTimeZone =
       parsedValue.match(/^[0-9]{4}$/) || // just the year, ie `2020`
-      parsedValue.match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/) || // YYYY-MM-DD format
-      parsedValue.match(/^.*?-[0-9]{2}:[0-9]{2}$/) || // `YYYY-MM-DDTHH:mm:ss-00:00` format
-      parsedValue.match(/^.*?-[0-9]{4}$/); // `YYYY-MM-DDTHH:mm:ss-0000` format
+      parsedValue.match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/); // YYYY-MM-DD format
     if (dateWithTimeZone) {
       date = new Date(date.getTime() + date.getTimezoneOffset() * 1000 * 60);
     }

--- a/src/field-types/date.ts
+++ b/src/field-types/date.ts
@@ -42,8 +42,10 @@ export class DateParser implements FieldParserInterface<Date> {
       return undefined;
     }
     let date = new Date(parsedValue);
-    // the `Date(string)` constructor parses some strings as GMT and some in the local timezone
-    // this attempts to detect cases that get parsed as GMT and adjusts accordingly
+    // The `Date(string)` constructor parses some strings as GMT and some in the local timezone.
+    // This attempts to detect cases that get parsed as GMT but should be parsed as local.
+    // Note that this does _not_ include cases with an explicit time zone specified, which
+    // should generally be parsed as-is and not converted to local time.
     const dateWithTimeZone =
       parsedValue.match(/^[0-9]{4}$/) || // just the year, ie `2020`
       parsedValue.match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/); // YYYY-MM-DD format

--- a/test/field-types/date.test.ts
+++ b/test/field-types/date.test.ts
@@ -48,12 +48,9 @@ describe('DateParser', () => {
     expect(response?.getTime()).to.equal(expected.getTime());
   });
 
-  it('can parse ISO8601 strings', async () => {
+  it('can parse ISO8601 strings without time zones', async () => {
     const parser = new DateParser();
     const response = parser.parseValue('2020-06-20T13:37:15');
-    const response2 = parser.parseValue('2020-06-20T13:37:15Z');
-    const response3 = parser.parseValue('2020-06-20T13:37:15-00:00');
-    const response4 = parser.parseValue('2020-06-20T13:37:15+00:00');
     const expected = new Date();
     expected.setHours(13);
     expected.setMinutes(37);
@@ -63,9 +60,25 @@ describe('DateParser', () => {
     expected.setDate(20);
     expected.setFullYear(2020);
     expect(response?.getTime()).to.equal(expected.getTime());
+  });
+
+  it('can parse ISO8601 strings with explicit time zones', async () => {
+    const parser = new DateParser();
+    const response = parser.parseValue('2020-06-20T13:37:15Z');
+    const response2 = parser.parseValue('2020-06-20T13:37:15-00:00');
+    const response3 = parser.parseValue('2020-06-20T13:37:15+00:00');
+    const expected = new Date();
+    // These date formats must be parsed with respect to UTC
+    expected.setUTCHours(13);
+    expected.setUTCMinutes(37);
+    expected.setUTCSeconds(15);
+    expected.setUTCMilliseconds(0);
+    expected.setUTCMonth(5);
+    expected.setUTCDate(20);
+    expected.setUTCFullYear(2020);
+    expect(response?.getTime()).to.equal(expected.getTime());
     expect(response2?.getTime()).to.equal(expected.getTime());
     expect(response3?.getTime()).to.equal(expected.getTime());
-    expect(response4?.getTime()).to.equal(expected.getTime());
   });
 
   it('can parse "c.a. yyyy" formatted dates', async () => {


### PR DESCRIPTION
Currently, the `DateParser` adds the local time zone offset to any dates specified in ISO 8601 format with an explicit time zone.

This is undesirable for a number of use cases which require the exact time stored in search documents (which is always in UTC). In particular, "Jan 1 at midnight" of any given year (in UTC) is often treated as a special case representing metadata date values that have been specified as a year only, and rendered accordingly on result tiles as the year alone.

This PR removes the exceptional handling for ISO 8601 dates to achieve greater consistency by ensuring that date strings specifying an explicit time zone will have it honored rather than erroneously ignored.