### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.4",
+  "version": "1.0.0",
   "name": "@internetarchive/field-parsers",
   "description": "Field parsers for Internet Archive metadata fields.",
   "author": "Internet Archive",


### PR DESCRIPTION
Version includes fixes for date parsing with explicit UTC-relative time zones.