### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/field-parsers",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/field-parsers",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "name": "@internetarchive/field-parsers",
   "description": "Field parsers for Internet Archive metadata fields.",
   "author": "Internet Archive",


### PR DESCRIPTION
Release the yes/no BooleanParser support (WEBDEV-8643) as 1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADu4aSJNrToPTHkdS1Jokp