### PR TITLE
WEBDEV-8641: Parse compact YYYYMMDD(HHMMSS) timestamps in DateParser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/field-parsers",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/field-parsers",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.1",
+  "version": "1.2.0",
   "name": "@internetarchive/field-parsers",
   "description": "Field parsers for Internet Archive metadata fields.",
   "author": "Internet Archive",

--- a/src/field-types/date.ts
+++ b/src/field-types/date.ts
@@ -10,8 +10,33 @@ export class DateParser implements FieldParserInterface<Date> {
 
   /** @inheritdoc */
   parseValue(rawValue: FieldParserRawValue): Date | undefined {
-    // try different date parsing
-    return this.parseJSDate(rawValue) || this.parseBracketDate(rawValue);
+    // try different date parsing. Compact all-digit timestamps are matched
+    // first with a strict regex so their result is deterministic; `Date.parse`
+    // behavior on non-ISO strings is implementation-defined across engines.
+    return (
+      this.parseCompactDate(rawValue) ||
+      this.parseJSDate(rawValue) ||
+      this.parseBracketDate(rawValue)
+    );
+  }
+
+  // handles compact all-digit timestamps like `20101106` (YYYYMMDD) and
+  // `20101106063500` (YYYYMMDDHHMMSS), used by fields such as `scandate`. The
+  // digits are interpreted as local time, matching how the YYYY-MM-DD form is
+  // normalized above.
+  private parseCompactDate(rawValue: FieldParserRawValue): Date | undefined {
+    if (typeof rawValue !== 'string') return undefined;
+    const match = rawValue
+      .trim()
+      .match(/^(\d{4})(\d{2})(\d{2})(?:(\d{2})(\d{2})(\d{2}))?$/);
+    if (!match) return undefined;
+    const [, year, month, day, hour = '00', minute = '00', second = '00'] =
+      match;
+    // a `T`-form with no time zone is parsed as local time
+    const date = new Date(
+      `${year}-${month}-${day}T${hour}:${minute}:${second}`
+    );
+    return Number.isNaN(date.getTime()) ? undefined : date;
   }
 
   // handles "[yyyy]" format

--- a/test/field-types/date.test.ts
+++ b/test/field-types/date.test.ts
@@ -123,6 +123,26 @@ describe('DateParser', () => {
     expect(response?.getTime()).toBe(expected.getTime());
   });
 
+  it('can parse a compact YYYYMMDDHHMMSS timestamp', async () => {
+    const parser = new DateParser();
+    const response = parser.parseValue('20101106063500');
+    // compact timestamps are interpreted as local time
+    const expected = new Date(2010, 10, 6, 6, 35, 0, 0);
+    expect(response?.getTime()).toBe(expected.getTime());
+  });
+
+  it('can parse a compact YYYYMMDD date', async () => {
+    const parser = new DateParser();
+    const response = parser.parseValue('20101106');
+    const expected = new Date(2010, 10, 6, 0, 0, 0, 0);
+    expect(response?.getTime()).toBe(expected.getTime());
+  });
+
+  it('returns undefined for an out-of-range compact date', async () => {
+    const parser = new DateParser();
+    expect(parser.parseValue('20101332')).toBeUndefined();
+  });
+
   it('returns undefined if it is a bad date', async () => {
     const parser = new DateParser();
     const response = parser.parseValue('absjkdvfnskj');


### PR DESCRIPTION
Teaches `DateParser` to parse compact all-digit timestamps like `20101106` and `20101106063500` (used by fields like `scandate`), as local time. Matched first with a strict regex so the result is deterministic across engines.

Moves the compact-date parsing that was living in item-metadata (`CompactDateParser`) down into the shared field-parsers layer. Item-metadata's `scandate` will delegate to this once 1.2.0 is published. Part of WEBDEV-8641 (TV Archive fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTzdCHTRpPpn9VUnFCFn3R